### PR TITLE
Enforce license renewal window, persist CAD license saves, and switch person search to first/last name

### DIFF
--- a/web/src/pages/police/Search.jsx
+++ b/web/src/pages/police/Search.jsx
@@ -94,7 +94,6 @@ export default function Search() {
   const isParamedics = layoutType === DEPARTMENT_LAYOUT.PARAMEDICS;
 
   const [searchType, setSearchType] = useState('person');
-  const [personLookupQuery, setPersonLookupQuery] = useState('');
   const [personFirstName, setPersonFirstName] = useState('');
   const [personLastName, setPersonLastName] = useState('');
   const [vehicleQuery, setVehicleQuery] = useState('');
@@ -112,7 +111,6 @@ export default function Search() {
   const [registrationStatusSaving, setRegistrationStatusSaving] = useState(false);
 
   const personQuery = [
-    String(personLookupQuery || '').trim(),
     String(personFirstName || '').trim(),
     String(personLastName || '').trim(),
   ].filter(Boolean).join(' ').trim();
@@ -132,7 +130,14 @@ export default function Search() {
     setResults([]);
     try {
       const endpoint = searchType === 'person' ? '/api/search/cad/persons' : '/api/search/cad/vehicles';
-      const data = await api.get(`${endpoint}?q=${encodeURIComponent(activeQuery)}`);
+      const query = searchType === 'person'
+        ? [
+            `first_name=${encodeURIComponent(String(personFirstName || '').trim())}`,
+            `last_name=${encodeURIComponent(String(personLastName || '').trim())}`,
+            `q=${encodeURIComponent(activeQuery)}`,
+          ].join('&')
+        : `q=${encodeURIComponent(activeQuery)}`;
+      const data = await api.get(`${endpoint}?${query}`);
       setResults(Array.isArray(data) ? data : []);
     } catch (err) {
       alert('Search failed:\n' + formatErr(err));
@@ -265,17 +270,7 @@ export default function Search() {
           </div>
 
           {searchType === 'person' ? (
-            <div className="grid grid-cols-1 md:grid-cols-[1.2fr_1fr_1fr_auto] gap-3 items-end">
-              <div>
-                <label className="block text-xs text-cad-muted mb-1">General Lookup</label>
-                <input
-                  type="text"
-                  value={personLookupQuery}
-                  onChange={(e) => setPersonLookupQuery(e.target.value)}
-                  placeholder="Name, citizen ID, licence no, or plate"
-                  className="w-full bg-cad-surface border border-cad-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-cad-accent"
-                />
-              </div>
+            <div className="grid grid-cols-1 md:grid-cols-[1fr_1fr_auto] gap-3 items-end">
               <div>
                 <label className="block text-xs text-cad-muted mb-1">First Name</label>
                 <input


### PR DESCRIPTION
### Motivation
- Ensure driver licences created from the FiveM bridge are saved and discoverable in CAD and to stop players from renewing a licence too early. 
- Replace the ambiguous "General Lookup" with explicit First/Last name lookup so person searches reliably return CAD-backed license records.

### Description
- Updated the Police Search UI to remove the "General Lookup" field and build person search requests from `first_name`, `last_name`, and `q` parameters instead of a single freeform field (`web/src/pages/police/Search.jsx`).
- Extended the CAD-native search API to accept `first_name` / `last_name` query params and added `personMatchesNameFilters` to apply those filters against resolved CAD/QBX person profiles so licence-backed records match first/last lookups (`server/src/routes/search.js`).
- Enforced renewal rules server-side in the FiveM integration `POST /licenses` handler by checking an existing CAD licence and returning `409` when renewal is attempted earlier than 3 days before expiry (`server/src/routes/fivem.js`).
- Added a FiveM resource preflight in the in-game submit flow that `GET`s the CAD licence before charging or posting a renewal, and blocks the client-side attempt with a player-facing message when it is not within 3 days of expiry; added `daysUntilDateOnly` helpers in both JS and Lua to support this (`server/fivem-resource/server.lua` and `server/src/routes/fivem.js`).

### Testing
- Static checks: ran `node --check server/src/routes/search.js` and `node --check server/src/routes/fivem.js`, both succeeded.
- Frontend build: ran `npm run build --workspace=web` and produced a successful production build of the web UI.
- UI smoke: launched a local `vite preview` and captured a UI screenshot with Playwright to verify the updated search form rendering.
- Lua validation: attempted `luac -p server/fivem-resource/server.lua` but `luac` is not available in this environment, so Lua bytecode checking could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996671a2b288327a14631ba4fd21fa1)