### PR TITLE
Fix cad_bridge poll loop nil interval comparisons

### DIFF
--- a/server/fivem-resource/server.lua
+++ b/server/fivem-resource/server.lua
@@ -1547,7 +1547,7 @@ end
 
 CreateThread(function()
   while true do
-    Wait(math.max(1000, Config.HeartbeatIntervalMs))
+    Wait(math.max(1000, tonumber(Config.HeartbeatIntervalMs) or 1500))
     if not hasBridgeConfig() then
       goto continue
     end
@@ -1907,7 +1907,7 @@ end
 local jobPollInFlight = false
 CreateThread(function()
   while true do
-    Wait(math.max(2000, Config.JobSyncPollIntervalMs))
+    Wait(math.max(2000, tonumber(Config.JobSyncPollIntervalMs) or 5000))
     if Config.JobSyncAdapter == 'none' then
       goto continue
     end
@@ -1991,7 +1991,7 @@ end
 local routePollInFlight = false
 CreateThread(function()
   while true do
-    Wait(math.max(2000, Config.RoutePollIntervalMs))
+    Wait(math.max(2000, tonumber(Config.RoutePollIntervalMs) or 5000))
     if not hasBridgeConfig() then
       goto continue
     end
@@ -2323,7 +2323,7 @@ end
 local finePollInFlight = false
 CreateThread(function()
   while true do
-    Wait(math.max(2000, Config.FinePollIntervalMs))
+    Wait(math.max(2000, tonumber(Config.FinePollIntervalMs) or 7000))
     if not hasBridgeConfig() then
       goto continue
     end


### PR DESCRIPTION
### Motivation
- Prevent runtime errors in `cad_bridge` poll loops where `Wait(math.max(..., Config.*IntervalMs))` could compare a number with `nil` and stop bridge workers, which can block in-game-created licenses from syncing to CAD search.

### Description
- Coerce interval config values with `tonumber(...)` and provide safe defaults in the heartbeat, job sync, route poll, and fine poll loops in `server/fivem-resource/server.lua` so `math.max(...)` always receives numeric values.

### Testing
- Attempted a Lua syntax/load check with `lua -e "assert(loadfile('server/fivem-resource/server.lua'))"` which failed because the Lua runtime is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699671ffff848327afabe812793c43dc)