### PR TITLE
Fix Lua trim helper causing tonumber base out-of-range errors

### DIFF
--- a/server/fivem-resource/config.lua
+++ b/server/fivem-resource/config.lua
@@ -1,7 +1,7 @@
 Config = {}
 
 local function trim(value)
-  return tostring(value or ''):gsub('^%s+', ''):gsub('%s+$', '')
+  return (tostring(value or ''):gsub('^%s+', ''):gsub('%s+$', ''))
 end
 
 local function unquote(value)


### PR DESCRIPTION
### Motivation
- Prevent `tonumber` from receiving an unintended second argument produced by chained `gsub` calls in `trim`, which was causing runtime errors like `bad argument #2 to 'tonumber' (base out of range)` in `getNumber`.

### Description
- Wrap the chained `gsub` calls in `trim` so it returns a single string value, updating `server/fivem-resource/config.lua` to `return (tostring(value or ''):gsub('^%s+', ''):gsub('%s+$', ''))`.

### Testing
- Attempted to run `luac -p server/fivem-resource/config.lua` and `lua -v` but both tools are not available in this environment, and I inspected the source to confirm the single-line fix was applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996753bc53483279d661799f554ca30)